### PR TITLE
various cleanups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,8 @@ edition = "2018"
 travis-ci = { repository = "ChristophWurst/nextcloud_appstore" }
 
 [dependencies]
-failure = "0.1"
 hyper = "0.13"
 hyper-tls = "0.4"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive" ] }
 serde_json = "1.0"
+thiserror = "1.0"

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,6 +1,8 @@
+use serde::Serialize;
+
 #[derive(Debug, Serialize)]
-pub struct NewRelease {
-    pub download: String,
-    pub signature: String,
+pub struct NewRelease<'a> {
+    pub download: &'a str,
+    pub signature: &'a str,
     pub nightly: bool,
 }


### PR DESCRIPTION
- use rust2018 macro imports
- remove unneeded cloning
- change error handling from failure to a (derived) enum
  - this allows for granular matching on error types by users of the api
  - `#[non_exhaustive]` is used to allow adding enum entries in the future without breaking compatibility